### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/spring-thrift-starter/src/main/java/info/developerblog/spring/thrift/client/ThriftClientBeanPostProcessor.java
+++ b/spring-thrift-starter/src/main/java/info/developerblog/spring/thrift/client/ThriftClientBeanPostProcessor.java
@@ -45,28 +45,28 @@ import java.util.Map;
 @ConditionalOnClass(ThriftClient.class)
 @ConditionalOnWebApplication
 public class ThriftClientBeanPostProcessor implements org.springframework.beans.factory.config.BeanPostProcessor {
-    Map<String, Class> beansToProcess = new HashMap<>();
+    private Map<String, Class> beansToProcess = new HashMap<>();
 
     @Autowired
-    TProtocolFactory protocolFactory;
+    private TProtocolFactory protocolFactory;
 
     @Autowired
-    LoadBalancerClient loadBalancerClient;
+    private LoadBalancerClient loadBalancerClient;
 
     @Autowired
-    PropertyResolver propertyResolver;
+    private PropertyResolver propertyResolver;
 
     @Autowired
-    RequestIdLogger requestIdLogger;
+    private RequestIdLogger requestIdLogger;
 
     @Autowired
-    DefaultListableBeanFactory beanFactory;
+    private DefaultListableBeanFactory beanFactory;
 
     @Autowired
-    KeyedPooledObjectFactory<ThriftClientKey, TServiceClient> thriftClientPoolFactory;
+    private KeyedPooledObjectFactory<ThriftClientKey, TServiceClient> thriftClientPoolFactory;
 
     @Autowired
-    KeyedObjectPool<ThriftClientKey, TServiceClient> thriftClientsPool;
+    private KeyedObjectPool<ThriftClientKey, TServiceClient> thriftClientsPool;
 
     public ThriftClientBeanPostProcessor() {
     }

--- a/spring-thrift-starter/src/main/java/info/developerblog/spring/thrift/client/pool/ThriftClientPooledObjectFactory.java
+++ b/spring-thrift-starter/src/main/java/info/developerblog/spring/thrift/client/pool/ThriftClientPooledObjectFactory.java
@@ -25,10 +25,10 @@ import ru.trylogic.spring.boot.thrift.beans.RequestIdLogger;
 public class ThriftClientPooledObjectFactory extends BaseKeyedPooledObjectFactory<ThriftClientKey, TServiceClient> {
     public static final int DEFAULT_CONNECTION_TIMEOUT = 1000;
     public static final int DEFAULT_READ_TIMEOUT = 30000;
-    TProtocolFactory protocolFactory;
-    LoadBalancerClient loadBalancerClient;
-    PropertyResolver propertyResolver;
-    RequestIdLogger requestIdLogger;
+    private TProtocolFactory protocolFactory;
+    private LoadBalancerClient loadBalancerClient;
+    private PropertyResolver propertyResolver;
+    private RequestIdLogger requestIdLogger;
 
     @Override
     public TServiceClient create(ThriftClientKey key) throws Exception {

--- a/spring-thrift-starter/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
+++ b/spring-thrift-starter/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
@@ -72,10 +72,10 @@ public class ThriftAutoConfiguration {
     
     public static class DefaultThriftConfigurer implements ThriftConfigurer {
         @Autowired(required = false)
-        GaugeService gaugeService;
+        private GaugeService gaugeService;
 
         @Autowired
-        LoggingThriftMethodInterceptor loggingThriftMethodInterceptor;
+        private LoggingThriftMethodInterceptor loggingThriftMethodInterceptor;
 
         public void configureProxyFactory(ProxyFactory proxyFactory) {
             proxyFactory.setOptimize(true);
@@ -94,13 +94,13 @@ public class ThriftAutoConfiguration {
         
         @Getter
         @Setter
-        ApplicationContext applicationContext;
+        private ApplicationContext applicationContext;
 
         @Autowired
-        TProtocolFactory protocolFactory;
+        private TProtocolFactory protocolFactory;
         
         @Autowired
-        ThriftConfigurer thriftConfigurer;
+        private ThriftConfigurer thriftConfigurer;
 
         @Override
         @SneakyThrows({NoSuchMethodException.class, ClassNotFoundException.class, InstantiationException.class, IllegalAccessException.class})

--- a/spring-thrift-starter/src/main/java/ru/trylogic/spring/boot/thrift/aop/MetricsThriftMethodInterceptor.java
+++ b/spring-thrift-starter/src/main/java/ru/trylogic/spring/boot/thrift/aop/MetricsThriftMethodInterceptor.java
@@ -8,7 +8,7 @@ import org.springframework.boot.actuate.metrics.GaugeService;
 @RequiredArgsConstructor
 public class MetricsThriftMethodInterceptor implements MethodInterceptor {
 
-    final GaugeService gaugeService;
+    private final GaugeService gaugeService;
     
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {

--- a/spring-thrift-starter/src/main/java/ru/trylogic/spring/boot/thrift/filters/RequestIdFilter.java
+++ b/spring-thrift-starter/src/main/java/ru/trylogic/spring/boot/thrift/filters/RequestIdFilter.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class RequestIdFilter implements Filter {
 
 	@Autowired
-	RequestIdLogger requestIdLogger;
+	private RequestIdLogger requestIdLogger;
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat