### PR TITLE
Deadlock hfx

### DIFF
--- a/autoconfigure/src/main/java/info/developerblog/spring/thrift/client/pool/ThriftClientPooledObjectFactory.java
+++ b/autoconfigure/src/main/java/info/developerblog/spring/thrift/client/pool/ThriftClientPooledObjectFactory.java
@@ -99,7 +99,7 @@ public class ThriftClientPooledObjectFactory extends BaseKeyedPooledObjectFactor
 
         super.passivateObject(key, pooledObject);
 
-        if (this.tracer.isTracing()) {
+        if (this.tracer.isTracing() && pooledObject.getSpan() != null) {
             Span span = pooledObject.getSpan();
             span.logEvent(Span.CLIENT_RECV);
             this.tracer.close(span);

--- a/examples/simple-client/src/test/java/info/developerblog/examples/thirft/poolfactory/PoolFactoryTests.java
+++ b/examples/simple-client/src/test/java/info/developerblog/examples/thirft/poolfactory/PoolFactoryTests.java
@@ -1,0 +1,76 @@
+package info.developerblog.examples.thirft.poolfactory;
+
+import example.TGreetingService;
+import info.developerblog.examples.thirft.simpleclient.SimpleClientApplication;
+import info.developerblog.spring.thrift.client.pool.ThriftClientKey;
+import info.developerblog.spring.thrift.client.pool.ThriftClientPool;
+import org.apache.commons.pool2.KeyedPooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.thrift.TServiceClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * @author Dmitry Zhikharev (jihor@ya.ru)
+ *         Created on 13.09.2016
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = SimpleClientApplication.class)
+@WebAppConfiguration
+@IntegrationTest("server.port:0")
+@DirtiesContext
+public class PoolFactoryTests {
+    @Autowired
+    private ThriftClientPool thriftClientsPool;
+
+    private final ThriftClientKey thriftClientKey = ThriftClientKey.builder()
+                                                                   .clazz(TGreetingService.Client.class)
+                                                                   .serviceName("greeting-service")
+                                                                   .path("/api")
+                                                                   .build();
+
+    private KeyedPooledObjectFactory<ThriftClientKey, TServiceClient> factory;
+    @PostConstruct
+    public void postConstruct(){
+        factory = thriftClientsPool.getFactory();
+    }
+
+    @Test
+    public void poolFactoryFullObjectLifecycleTest() throws Exception {
+        PooledObject<TServiceClient> pooledObject = factory.makeObject(thriftClientKey);
+        factory.activateObject(thriftClientKey, pooledObject);
+        factory.validateObject(thriftClientKey, pooledObject);
+        factory.passivateObject(thriftClientKey, pooledObject);
+    }
+
+    @Test
+    public void poolFactoryNonstandardObjectLifecycleTest() throws Exception {
+        // Pooled object may be created and passivated right away
+        // E.g. GenericKeyedObjectPool: returnObject() -> reuseCapacity() -> create() and addIdleObject(), which invokes passivate()
+        PooledObject<TServiceClient> pooledObject = factory.makeObject(thriftClientKey);
+        factory.passivateObject(thriftClientKey, pooledObject);
+    }
+
+    @Test
+    public void poolFactoryOverlappingObjectLifecyclesTest() throws Exception {
+        PooledObject<TServiceClient> pooledObject1 = factory.makeObject(thriftClientKey);
+
+        // activateObject leads to tracer.isEnabled() --> true
+        factory.activateObject(thriftClientKey, pooledObject1);
+        factory.validateObject(thriftClientKey, pooledObject1);
+
+        // Create another pooled object and passivate it right away.
+        // See poolFactoryNonstandardObjectLifecycleTest() for details
+        PooledObject<TServiceClient> pooledObject2 = factory.makeObject(thriftClientKey);
+        factory.passivateObject(thriftClientKey, pooledObject2);
+
+    }
+}

--- a/examples/test-protocol/build.gradle
+++ b/examples/test-protocol/build.gradle
@@ -49,7 +49,7 @@ idea {
 compileJava.dependsOn generateThriftJava
 
 dependencies {
-    def thriftVersion = '0.9.1';
+    def thriftVersion = '0.9.2';
     Map platformMapping = [
             (OperatingSystem.WINDOWS) : 'win',
             (OperatingSystem.MAC_OS) : 'osx'

--- a/examples/test-protocol/build.gradle
+++ b/examples/test-protocol/build.gradle
@@ -49,7 +49,7 @@ idea {
 compileJava.dependsOn generateThriftJava
 
 dependencies {
-    def thriftVersion = '0.9.2';
+    def thriftVersion = '0.9.1';
     Map platformMapping = [
             (OperatingSystem.WINDOWS) : 'win',
             (OperatingSystem.MAC_OS) : 'osx'


### PR DESCRIPTION
Hi!

`ThriftClientPooledObjectFactory.passivateObject()` method will throw a `NPE` if the pooled object was never activated before and a pooled object of the same service name was created and activated before.

A `create --> passivate` lifecycle (instead of the usual `create --> activate --> passivate` one) may occur when the new object is created in `GenericKeyedObjectPool.returnObject()` method. This typically occurs when all objects from pool are already used. In `returnObject()` method, a new object is created and the oldest existing one is discarded. The newly created object is then passivated and placed into `idleObjects` (see `GenericKeyedObjectPool:835` - `reuseCapacity(`) creates a pooled object and invokes `addIdleObject()` on it, which passivates the new object right away). The existing bug leads to `PooledObject`s being created and stored in `allObjects`, but not present in `idleObjects` (they throw an `NPE` right before being placed there), which leads to deadlocking the pool.

Worst of all, the exception is then swallowed by the `BaseGenericObjectPool.swallowException()` leaving us a deadlocked pool and a clean log. This `NPE` is caused by `Spec` being `null`, when `tracer.isActive() == true`.

This pull request contains a simple workaround and a test for the `ThriftClientPoolFactoryConfiguration` class.