### PR TITLE
Support for Spring Boot 1.4.X

### DIFF
--- a/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
+++ b/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.boot.actuate.metrics.GaugeService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.context.embedded.RegistrationBean;
+import org.springframework.boot.web.servlet.RegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.7.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.2.RELEASE")
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.+'
     }
 }
@@ -12,7 +12,7 @@ buildscript {
 
 allprojects {
     group = 'info.developerblog.spring.thrift'
-    version = '1.3.0.RELEASE'
+    version = '1.4.0-SNAPSHOT'
 
     repositories {
         jcenter()
@@ -25,15 +25,15 @@ allprojects {
 
     dependencyManagement {
         imports {
-            mavenBom "org.springframework.cloud:spring-cloud-starter-parent:Brixton.SR6"
+            mavenBom "org.springframework.cloud:spring-cloud-starter-parent:Camden.SR3"
         }
 
         dependencies {
             dependency 'org.projectlombok:lombok:1.16.8'
             dependency 'org.codehaus.groovy:groovy-all:2.4.5'
-            dependency 'org.apache.thrift:libthrift:0.9.2'
-            dependency 'org.apache.commons:commons-pool2:2.4.1'
-            dependency 'org.apache.commons:commons-lang3:3.4'
+            dependency 'org.apache.thrift:libthrift:0.9.3'
+            dependency 'org.apache.commons:commons-pool2:2.4.2'
+            dependency 'org.apache.commons:commons-lang3:3.5'
         }
     }
 


### PR DESCRIPTION
Little changes for supporting Spring Boot 1.4.X and some updated dependencies. It needs more work in the tests where a lot of deprecated annotations are being used.

I hope it helps