### PR TITLE
add possible reconfiguration of max total threads of thriftClientsPool

### DIFF
--- a/autoconfigure/src/main/java/info/developerblog/spring/thrift/client/PoolConfiguration.java
+++ b/autoconfigure/src/main/java/info/developerblog/spring/thrift/client/PoolConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +42,12 @@ public class PoolConfiguration {
     @Value("${thrift.client.max.threads:8}")
     private int maxThreads;
 
+    @Value("${thrift.client.max.idle.threads:8}")
+    private int maxIdleThreads;
+
+    @Value("${thrift.client.max.total.threads:8}")
+    private int maxTotalThreads;
+
     @Autowired
     private Tracing tracing;
 
@@ -48,10 +55,11 @@ public class PoolConfiguration {
     private Tracer tracer;
 
     @Bean
+    @ConditionalOnMissingBean(name = "thriftClientsPool")
     public KeyedObjectPool<ThriftClientKey, TServiceClient> thriftClientsPool() {
         GenericKeyedObjectPoolConfig poolConfig = new GenericKeyedObjectPoolConfig();
-        poolConfig.setMaxTotal(maxThreads);
-        poolConfig.setMaxIdlePerKey(maxThreads);
+        poolConfig.setMaxTotal(maxTotalThreads);
+        poolConfig.setMaxIdlePerKey(maxIdleThreads);
         poolConfig.setMaxTotalPerKey(maxThreads);
         poolConfig.setJmxEnabled(false); //cause spring will autodetect itself
         return new ThriftClientPool(thriftClientPoolFactory(), poolConfig);

--- a/examples/simple-client/src/test/java/info/developerblog/examples/thirft/simpleclient/TGreetingServiceHandlerTests.java
+++ b/examples/simple-client/src/test/java/info/developerblog/examples/thirft/simpleclient/TGreetingServiceHandlerTests.java
@@ -43,6 +43,12 @@ public class TGreetingServiceHandlerTests {
     @Value("${thrift.client.max.threads}")
     private int maxThreads;
 
+    @Value("${thrift.client.max.idle.threads:8}")
+    private int maxIdleThreads;
+
+    @Value("${thrift.client.max.total.threads:8}")
+    private int maxTotalThreads;
+
     @Test
     public void testSimpleCall() throws Exception {
         assertEquals("Hello John Smith", greetingService.getGreeting("Smith", "John"));
@@ -92,9 +98,9 @@ public class TGreetingServiceHandlerTests {
 
     @Test
     public void testClientThreadCount() {
-        assertEquals(clientPool.getMaxIdlePerKey(), maxThreads);
+        assertEquals(clientPool.getMaxIdlePerKey(), maxIdleThreads);
         assertEquals(clientPool.getMaxTotalPerKey(), maxThreads);
-        assertEquals(clientPool.getMaxTotal(), maxThreads);
+        assertEquals(clientPool.getMaxTotal(), maxTotalThreads);
     }
 
 }


### PR DESCRIPTION
Hi. Currently thriftClientsPool KeyedObjectPool config has the same values for all maxTotal, maxIdlePerKey and maxTotalPerKey properties which causes issues in production related with pool exhaustion in situation when one client (under ThriftClientKey instance) is overloaded. 
So I've added different system variables for maxTotal and maxIdlePerKey properties.

thriftClientsPool bean is also made conditional on missing bean with the same name to add possibility to reconfigure the pool and have different KeyedObjectPool implementation. 