### PR TITLE
Allow rethrow thrift exception in proxy while error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ generated-src
 **/private
 *~
 .gradle
+.gradletasknamecache
 /build
 /out
 /intTestHomeDir

--- a/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
+++ b/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
@@ -64,8 +64,6 @@ public class ThriftAutoConfiguration {
         private LoggingThriftMethodInterceptor loggingThriftMethodInterceptor;
 
         public void configureProxyFactory(ProxyFactory proxyFactory) {
-            proxyFactory.setOptimize(true);
-
             if (meterRegistry != null) {
                 proxyFactory.addAdvice(new MetricsThriftMethodInterceptor(meterRegistry));
             }

--- a/examples/simple-handler/src/main/java/info/developerblog/examples/thirft/simpleclient/GreetingMessageService.java
+++ b/examples/simple-handler/src/main/java/info/developerblog/examples/thirft/simpleclient/GreetingMessageService.java
@@ -1,0 +1,25 @@
+package info.developerblog.examples.thirft.simpleclient;
+
+import example.TName;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GreetingMessageService {
+
+    public String constructGreeting(TName name) {
+        StringBuilder result = new StringBuilder();
+
+        result.append("Hello ");
+
+        if(name.isSetStatus()) {
+            result.append(org.springframework.util.StringUtils.capitalize(name.getStatus().name().toLowerCase()));
+            result.append(" ");
+        }
+
+        result.append(name.getFirstName());
+        result.append(" ");
+        result.append(name.getSecondName());
+
+        return result.toString();
+    }
+}

--- a/examples/simple-handler/src/main/java/info/developerblog/examples/thirft/simpleclient/TGreetingServiceHandler.java
+++ b/examples/simple-handler/src/main/java/info/developerblog/examples/thirft/simpleclient/TGreetingServiceHandler.java
@@ -2,7 +2,6 @@ package info.developerblog.examples.thirft.simpleclient;
 
 import example.TGreetingService;
 import example.TName;
-import org.apache.thrift.TException;
 import ru.trylogic.spring.boot.thrift.annotation.ThriftController;
 
 /**
@@ -11,21 +10,14 @@ import ru.trylogic.spring.boot.thrift.annotation.ThriftController;
 @ThriftController("/api")
 public class TGreetingServiceHandler implements TGreetingService.Iface {
 
+    private final GreetingMessageService greetingMessageService;
+
+    public TGreetingServiceHandler(GreetingMessageService greetingMessageService) {
+        this.greetingMessageService = greetingMessageService;
+    }
+
     @Override
-    public String greet(TName name) throws TException {
-        StringBuilder result = new StringBuilder();
-
-        result.append("Hello ");
-
-        if(name.isSetStatus()) {
-            result.append(org.springframework.util.StringUtils.capitalize(name.getStatus().name().toLowerCase()));
-            result.append(" ");
-        }
-
-        result.append(name.getFirstName());
-        result.append(" ");
-        result.append(name.getSecondName());
-
-        return result.toString();
+    public String greet(TName name) {
+        return greetingMessageService.constructGreeting(name);
     }
 }

--- a/examples/simple-handler/src/test/java/info/developerblog/examples/thirft/simpleclient/TGreetingServiceHandlerTests.java
+++ b/examples/simple-handler/src/test/java/info/developerblog/examples/thirft/simpleclient/TGreetingServiceHandlerTests.java
@@ -2,7 +2,7 @@ package info.developerblog.examples.thirft.simpleclient;
 
 import example.TGreetingService;
 import example.TName;
-import example.TStatus;
+import org.apache.thrift.TApplicationException;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.THttpClient;
@@ -12,17 +12,21 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 /**
  * Created by aleksandr on 01.09.15.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@SpringBootTest(classes = {Application.class, TGreetingServiceHandlerTests.MockConfiguration.class}, webEnvironment = RANDOM_PORT)
 public class TGreetingServiceHandlerTests {
 
     @LocalServerPort
@@ -30,6 +34,9 @@ public class TGreetingServiceHandlerTests {
 
     @Autowired
     TProtocolFactory protocolFactory;
+
+    @Autowired
+    GreetingMessageService greetingMessageService;
 
     TGreetingService.Iface client;
 
@@ -45,11 +52,25 @@ public class TGreetingServiceHandlerTests {
     @Test
     public void testSimpleCall() throws Exception {
         TName name = new TName("John", "Smith");
-
-        assertEquals("Hello John Smith", client.greet(name));
-
-        name.setStatus(TStatus.MR);
+        doReturn("Hello Mr John Smith").when(greetingMessageService).constructGreeting(name);
 
         assertEquals("Hello Mr John Smith", client.greet(name));
+    }
+
+    @Test(expected = TApplicationException.class)
+    public void testThrowException() throws Exception {
+        doThrow(new RuntimeException()).when(greetingMessageService).constructGreeting(any());
+
+        client.greet(new TName("John", "Doe"));
+    }
+
+    @TestConfiguration
+    public static class MockConfiguration {
+
+        @Bean
+        @Primary
+        public GreetingMessageService greetingMessageService() {
+            return mock(GreetingMessageService.class);
+        }
     }
 }


### PR DESCRIPTION
With enabled proxy factory optimization any throwed checked exception in thrift controller proxy results in UndeclaredThrowableException when that exception not declared in throws clause in implementation service.

For example if I have thrift service
```
public class TSampleService {
    public interface Iface {
        public void some() throws org.apache.thrift.TException;
        ...
    }
}
```

with implementation
```
public class TSampleServiceImpl implements TSampleService.Iface
@Override
public void some() {
   ...
}
```

and I add error handling proxy advice via LoggingThriftMethodInterceptor for thrift controller that catch any custom exception that throwed in TSampleServiceImpl and wrap it to TException than UndeclaredThrowableException will be throwed that leads to org.apache.thrift.transport.TTransportException: HTTP Response code: 406.

For workaround we can add throws TException for any implementation method
```
public class TSampleServiceImpl implements TSampleService.Iface
@Override
public void some() throws org.apache.thrift.TException {
   ...
}
```
but this is not very obviously way and leads to warning for codestyle tools

