### PR TITLE
Add tracing autoconfiguration to the server side

### DIFF
--- a/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
+++ b/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/ThriftAutoConfiguration.java
@@ -1,5 +1,6 @@
 package ru.trylogic.spring.boot.thrift;
 
+import brave.Tracer;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.Getter;
 import lombok.Setter;
@@ -24,6 +25,7 @@ import org.springframework.util.ClassUtils;
 import ru.trylogic.spring.boot.thrift.annotation.ThriftController;
 import ru.trylogic.spring.boot.thrift.aop.LoggingThriftMethodInterceptor;
 import ru.trylogic.spring.boot.thrift.aop.MetricsThriftMethodInterceptor;
+import ru.trylogic.spring.boot.thrift.aop.TracingThriftMethodInterceptor;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRegistration;
@@ -60,12 +62,18 @@ public class ThriftAutoConfiguration {
         @Autowired(required = false)
         private MeterRegistry meterRegistry;
 
+        @Autowired(required = false)
+        private Tracer tracer;
+
         @Autowired
         private LoggingThriftMethodInterceptor loggingThriftMethodInterceptor;
 
         public void configureProxyFactory(ProxyFactory proxyFactory) {
             if (meterRegistry != null) {
                 proxyFactory.addAdvice(new MetricsThriftMethodInterceptor(meterRegistry));
+            }
+            if (tracer != null) {
+                proxyFactory.addAdvice(new TracingThriftMethodInterceptor(tracer));
             }
             proxyFactory.addAdvice(loggingThriftMethodInterceptor);
         }

--- a/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/aop/TracingThriftMethodInterceptor.java
+++ b/autoconfigure/src/main/java/ru/trylogic/spring/boot/thrift/aop/TracingThriftMethodInterceptor.java
@@ -1,0 +1,33 @@
+package ru.trylogic.spring.boot.thrift.aop;
+
+import brave.Span;
+import brave.Tracer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+public class TracingThriftMethodInterceptor implements MethodInterceptor {
+    private final Tracer tracer;
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        final Span span = tracer.nextSpan()
+                .name(invocation.getMethod().getName())
+                .kind(Span.Kind.SERVER)
+                .start();
+
+        try {
+            final Object result = invocation.proceed();
+            span.finish();
+            return result;
+        } catch (Exception e) {
+            span.error(e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Similar to the client - if tracing is enabled spring creates spans named `post`
(based on the request method) which is not very helpful.
This will add a span named after the method called.

This is a work in progress as I have to do some more testing though